### PR TITLE
Fix incorrect error message

### DIFF
--- a/Editor/Commands/ComponentCommandHandler.cs
+++ b/Editor/Commands/ComponentCommandHandler.cs
@@ -72,7 +72,7 @@ public class ComponentCommandHandler : ICommandHandler
 			return new CommandResponse()
 			{
 				CommandId = request.CommandId,
-				Content = "Argument 'componentType' is required",
+				Content = "Argument 'gameObjectId' is required",
 				IsError = true
 			};
 		}


### PR DESCRIPTION
## Summary
- correct the error message for missing `gameObjectId` in component creation

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685beea2cee0832cbee8bb6633f4e7b2